### PR TITLE
Making MagnetIndexerGenerator to not depend on dependencies specific to high level modules.

### DIFF
--- a/magnet-processor/src/main/java/magnet/FactoryIndexGenerator.kt
+++ b/magnet-processor/src/main/java/magnet/FactoryIndexGenerator.kt
@@ -20,6 +20,7 @@ import com.squareup.javapoet.AnnotationSpec
 import com.squareup.javapoet.ClassName
 import com.squareup.javapoet.JavaFile
 import com.squareup.javapoet.TypeSpec
+import com.squareup.javapoet.MethodSpec
 import magnet.internal.FactoryIndex
 import javax.lang.model.element.Element
 import javax.lang.model.element.ExecutableElement
@@ -101,6 +102,7 @@ class FactoryIndexGenerator {
                                 implTarget
                         )
                 )
+                .addMethod(generateGetterForTargetClass(implTypeClassName))
                 .build()
     }
 
@@ -114,6 +116,19 @@ class FactoryIndexGenerator {
                 .addMember("type", "\$T.class", implTypeClassName)
                 .addMember("target", "\$S", implTarget)
                 .build()
+    }
+
+    private fun generateGetterForTargetClass(implTypeClassName: ClassName): MethodSpec {
+        return MethodSpec
+                .methodBuilder(METHOD_NAME_GET_TYPE_CLASS)
+                .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
+                .returns(Class::class.java)
+                .addStatement("return \$T.class", implTypeClassName)
+                .build()
+    }
+
+    companion object {
+        const val METHOD_NAME_GET_TYPE_CLASS = "getTypeClass"
     }
 
 }

--- a/magnet-processor/src/main/java/magnet/MagnetIndexerGenerator.kt
+++ b/magnet-processor/src/main/java/magnet/MagnetIndexerGenerator.kt
@@ -84,7 +84,7 @@ class MagnetIndexerGenerator {
         val impls = mutableListOf<Impl>()
         indexElements.forEach {
             parseFactoryIndexAnnotation(it, factoryIndexClassName) { implTypeName, implFactoryName, implTargetName ->
-                impls.add(Impl(implTypeName, implTargetName, implFactoryName))
+                impls.add(Impl(implTypeName, implTargetName, implFactoryName, it))
             }
         }
 

--- a/magnet-processor/src/main/java/magnet/indexer/IndexGeneratorVisitor.kt
+++ b/magnet-processor/src/main/java/magnet/indexer/IndexGeneratorVisitor.kt
@@ -16,8 +16,8 @@
 
 package magnet.indexer
 
-import com.squareup.javapoet.ClassName
 import com.squareup.javapoet.CodeBlock
+import magnet.FactoryIndexGenerator
 import magnet.indexer.model.Impl
 import magnet.indexer.model.Index
 import magnet.indexer.model.IndexVisitor
@@ -53,8 +53,9 @@ class IndexGeneratorVisitor : IndexVisitor {
         val targetsName = "ranges${++sectionIndex}"
 
         indexBuilder.addStatement(
-                "index.put(\$T.class, \$L)",
-                ClassName.bestGuess(section.type),
+                "index.put(\$T.\$N(), \$L)",
+                section.factoryIndex,
+                FactoryIndexGenerator.METHOD_NAME_GET_TYPE_CLASS,
                 targetsName
         )
 
@@ -73,8 +74,9 @@ class IndexGeneratorVisitor : IndexVisitor {
         if (generateSingleRange) {
             currentSection?.let {
                 indexBuilder.addStatement(
-                        "index.put(\$T.class, new \$T(\$L, \$L, \$S))",
-                        ClassName.bestGuess(it.type),
+                        "index.put(\$T.\$N(), new \$T(\$L, \$L, \$S))",
+                        it.factoryIndex,
+                        FactoryIndexGenerator.METHOD_NAME_GET_TYPE_CLASS,
                         magnet.internal.Range::class.java,
                         range.from,
                         range.impls.size,

--- a/magnet-processor/src/main/java/magnet/indexer/SectionsCreatorVisitor.kt
+++ b/magnet-processor/src/main/java/magnet/indexer/SectionsCreatorVisitor.kt
@@ -54,7 +54,7 @@ class SectionsCreatorVisitor : ImplVisitor {
     private fun addRange(impl: Impl) {
 
         val section = sectionsByType.getOrPut(impl.type) {
-            Section(impl.type)
+            Section(impl.type, impl.factoryIndex)
         }
 
         val rangeIndex = calculateIndex()

--- a/magnet-processor/src/main/java/magnet/indexer/model/Impl.kt
+++ b/magnet-processor/src/main/java/magnet/indexer/model/Impl.kt
@@ -16,10 +16,13 @@
 
 package magnet.indexer.model
 
+import javax.lang.model.element.Element
+
 data class Impl(
         val type: String,
         val target: String,
-        val factory: String
+        val factory: String,
+        val factoryIndex: Element
 ) {
     fun accept(visitor: ImplVisitor) {
         visitor.visit(this)

--- a/magnet-processor/src/main/java/magnet/indexer/model/Section.kt
+++ b/magnet-processor/src/main/java/magnet/indexer/model/Section.kt
@@ -16,8 +16,11 @@
 
 package magnet.indexer.model
 
+import javax.lang.model.element.Element
+
 data class Section(
-        val type: String
+        val type: String,
+        val factoryIndex: Element
 ) {
     val ranges = mutableMapOf<String, Range>()
 

--- a/magnet-processor/src/test/java/magnet/IndexerTest.kt
+++ b/magnet-processor/src/test/java/magnet/IndexerTest.kt
@@ -1,11 +1,26 @@
 package magnet
 
 import com.google.common.truth.Truth.assertThat
+import com.sun.tools.javac.model.JavacElements
+import com.sun.tools.javac.util.Context
 import magnet.indexer.Indexer
 import magnet.indexer.model.Impl
+import org.junit.Before
 import org.junit.Test
+import javax.lang.model.element.Element
 
 class IndexerTest {
+
+    private lateinit var factoryElement: Element
+
+    @Before
+    fun setUp() {
+        val context = Context()
+        val elements = JavacElements.instance(context)
+        factoryElement = elements.getTypeElement(
+                Object::class.java.canonicalName
+        )
+    }
 
     @Test
     fun test_IndexNodes() {
@@ -33,39 +48,39 @@ class IndexerTest {
 
     fun unsortedNodes(): List<Impl> {
         return listOf(
-                Impl("CType", "four", "Factory"),
-                Impl("CType", "two", "Factory"),
-                Impl("CType", "one", "Factory"),
-                Impl("CType", "three", "Factory"),
-                Impl("CType", "four", "Factory"),
+                Impl("CType", "four", "Factory", factoryElement),
+                Impl("CType", "two", "Factory", factoryElement),
+                Impl("CType", "one", "Factory", factoryElement),
+                Impl("CType", "three", "Factory", factoryElement),
+                Impl("CType", "four", "Factory", factoryElement),
 
-                Impl("BType", "", "Factory"),
-                Impl("BType", "", "Factory"),
-                Impl("BType", "", "Factory"),
+                Impl("BType", "", "Factory", factoryElement),
+                Impl("BType", "", "Factory", factoryElement),
+                Impl("BType", "", "Factory", factoryElement),
 
-                Impl("AType", "", "Factory"),
-                Impl("AType", "one", "Factory"),
-                Impl("AType", "", "Factory"),
-                Impl("AType", "two", "Factory"),
-                Impl("AType", "one", "Factory")
+                Impl("AType", "", "Factory", factoryElement),
+                Impl("AType", "one", "Factory", factoryElement),
+                Impl("AType", "", "Factory", factoryElement),
+                Impl("AType", "two", "Factory", factoryElement),
+                Impl("AType", "one", "Factory", factoryElement)
         )
     }
 
     fun sortedNodes(): List<Impl> {
         return listOf(
-                Impl("AType", "", "Factory"),
-                Impl("AType", "", "Factory"),
-                Impl("AType", "one", "Factory"),
-                Impl("AType", "one", "Factory"),
-                Impl("AType", "two", "Factory"),
-                Impl("BType", "", "Factory"),
-                Impl("BType", "", "Factory"),
-                Impl("BType", "", "Factory"),
-                Impl("CType", "four", "Factory"),
-                Impl("CType", "four", "Factory"),
-                Impl("CType", "one", "Factory"),
-                Impl("CType", "three", "Factory"),
-                Impl("CType", "two", "Factory")
+                Impl("AType", "", "Factory", factoryElement),
+                Impl("AType", "", "Factory", factoryElement),
+                Impl("AType", "one", "Factory", factoryElement),
+                Impl("AType", "one", "Factory", factoryElement),
+                Impl("AType", "two", "Factory", factoryElement),
+                Impl("BType", "", "Factory", factoryElement),
+                Impl("BType", "", "Factory", factoryElement),
+                Impl("BType", "", "Factory", factoryElement),
+                Impl("CType", "four", "Factory", factoryElement),
+                Impl("CType", "four", "Factory", factoryElement),
+                Impl("CType", "one", "Factory", factoryElement),
+                Impl("CType", "three", "Factory", factoryElement),
+                Impl("CType", "two", "Factory", factoryElement)
         )
     }
 

--- a/magnet-processor/src/test/resources/MagnetProcessorTest/generated/MagnetIndexer.java
+++ b/magnet-processor/src/test/resources/MagnetProcessorTest/generated/MagnetIndexer.java
@@ -1,13 +1,15 @@
 package magnet;
 
-import app.MenuItem;
-import app.Page;
 import app.extension.MagnetHomePageFactory;
 import app.extension.MagnetHomePageMenuItemFactory;
 import app.extension.MagnetUserPageFactory;
 import app.extension.MagnetUserPageMenuItemFactory;
+
 import java.util.HashMap;
 import java.util.Map;
+
+import magnet.index.app_extension_MagnetHomePageFactory;
+import magnet.index.app_extension_MagnetUserPageMenuItemFactory;
 import magnet.internal.Factory;
 import magnet.internal.Range;
 
@@ -27,8 +29,8 @@ public final class MagnetIndexer {
         ranges1.put("extended-menu", new Range(0, 1, "extended-menu"));
         ranges1.put("main-menu", new Range(1, 1, "main-menu"));
 
-        index.put(MenuItem.class, ranges1);
-        index.put(Page.class, new Range(2, 2, ""));
+        index.put(app_extension_MagnetUserPageMenuItemFactory.getTypeClass(), ranges1);
+        index.put(app_extension_MagnetHomePageFactory.getTypeClass(), new Range(2, 2, ""));
 
         implementationManager.register(factories, index);
     }

--- a/magnet-processor/src/test/resources/MagnetProcessorTest/generated/app_extension_MagnetHomePageFactory.java
+++ b/magnet-processor/src/test/resources/MagnetProcessorTest/generated/app_extension_MagnetHomePageFactory.java
@@ -9,4 +9,8 @@ import magnet.internal.FactoryIndex;
         type = Page.class,
         target = ""
 )
-public final class app_extension_MagnetHomePageFactory {}
+public final class app_extension_MagnetHomePageFactory {
+    public static Class getTypeClass() {
+        return Page.class;
+    }
+}

--- a/magnet-processor/src/test/resources/MagnetProcessorTest/generated/app_extension_MagnetUserPageMenuItemFactory.java
+++ b/magnet-processor/src/test/resources/MagnetProcessorTest/generated/app_extension_MagnetUserPageMenuItemFactory.java
@@ -9,4 +9,8 @@ import magnet.internal.FactoryIndex;
         type = MenuItem.class,
         target = "extended-menu"
 )
-public final class app_extension_MagnetUserPageMenuItemFactory {}
+public final class app_extension_MagnetUserPageMenuItemFactory {
+    public static Class getTypeClass() {
+        return MenuItem.class;
+    }
+}


### PR DESCRIPTION
**Problem statement:**
Now the module which utilises `MagnetizeImplementations` has to have dependencies on the modules which doesn't extend any particular interfaces.

Here is the example:
![image](https://user-images.githubusercontent.com/3289717/37256497-7b2f681c-256c-11e8-8c0d-76375853535a.png)

`Module2` provides the implementation of `Foo` declared in `CommonLib` for `Module1`.
The module `app` legitimaly has dependency on `Module1` and `Module2`, but also it is required to have a dependency on module `CommonLib` (red colored arrow) as the generated `MagnetIndexer` explicitly uses `Foo` name to store it inside `index`.

**Solution:**
Now each generated Factory in the package `magnet.index` has additional static method `getTypeClass()` which returns the type of the interface the implementation implements and this type is used as a `Class` by `MagnetIndexer`'s implementation(instead of explicit using `Foo` and other extensible interfaces) which eliminates necessity the `app` module to depend on `CommonLib` module.