### PR TITLE
Allow secondary private constructors

### DIFF
--- a/magnet-library/magnet-processor/src/main/java/magnet/processor/instances/FactoryFromClassAnnotationParser.kt
+++ b/magnet-library/magnet-processor/src/main/java/magnet/processor/instances/FactoryFromClassAnnotationParser.kt
@@ -20,6 +20,7 @@ import com.squareup.javapoet.ClassName
 import magnet.Instance
 import magnet.processor.MagnetProcessorEnv
 import magnet.processor.common.ValidationException
+import javax.lang.model.element.Modifier
 import javax.lang.model.element.TypeElement
 import javax.lang.model.util.ElementFilter
 
@@ -74,11 +75,14 @@ internal class FactoryFromClassAnnotationParser(
 
     private fun parseCreateMethod(element: TypeElement): CreateMethod {
 
-        val constructors = ElementFilter.constructorsIn(element.enclosedElements)
+        val constructors = ElementFilter
+            .constructorsIn(element.enclosedElements)
+            .filterNot { it.modifiers.contains(Modifier.PRIVATE) || it.modifiers.contains(Modifier.PROTECTED) }
         if (constructors.size != 1) {
             throw ValidationException(
                 element = element,
-                message = "Classes annotated with ${Instance::class.java} must have exactly one constructor."
+                message = "Classes annotated with ${Instance::class.java} must have exactly one " +
+                    "public or package-protected constructor."
             )
         }
 

--- a/magnet-library/magnet-processor/src/test/java/magnet/processor/MagnetProcessorTest.kt
+++ b/magnet-library/magnet-processor/src/test/java/magnet/processor/MagnetProcessorTest.kt
@@ -347,6 +347,68 @@ class MagnetProcessorTest {
 
     }
 
+    @Test
+    fun generateFactory_FailOnAdditionalPackageProtectedConstructor() {
+
+        val compilation = Compiler.javac()
+            .withProcessors(MagnetProcessor())
+            .compile(
+                withResource("HomePageConstructorsWithAdditionalPackageProtected.java"),
+                withResource("Page.java")
+            )
+
+        assertThat(compilation).failed()
+        assertThat(compilation).hadErrorContaining("must have exactly one public or package-protected constructor")
+    }
+
+    @Test
+    fun generateFactory_FailWithNoPublicOrPackageProtectedConstructor() {
+
+        val compilation = Compiler.javac()
+            .withProcessors(MagnetProcessor())
+            .compile(
+                withResource("HomePageConstructorsWithNoPublicOrPackageProtected.java"),
+                withResource("Page.java")
+            )
+
+        assertThat(compilation).failed()
+        assertThat(compilation).hadErrorContaining("must have exactly one public or package-protected constructor")
+    }
+
+    @Test
+    fun generateFactory_AllowAdditionalPrivateConstructor() {
+
+        val compilation = Compiler.javac()
+            .withProcessors(MagnetProcessor())
+            .compile(
+                withResource("HomePageConstructorsWithAdditionalPrivate.java"),
+                withResource("Page.java")
+            )
+
+        assertThat(compilation).succeededWithoutWarnings()
+
+        assertThat(compilation)
+            .generatedSourceFile("app/extension/HomePageConstructorsWithAdditionalPrivateMagnetFactory")
+            .hasSourceEquivalentTo(withResource("generated/HomePageConstructorsWithAdditionalPrivateMagnetFactory.java"))
+    }
+
+    @Test
+    fun generateFactory_AllowAdditionalProtectedConstructor() {
+
+        val compilation = Compiler.javac()
+            .withProcessors(MagnetProcessor())
+            .compile(
+                withResource("HomePageConstructorsWithAdditionalProtected.java"),
+                withResource("Page.java")
+            )
+
+        assertThat(compilation).succeededWithoutWarnings()
+
+        assertThat(compilation)
+            .generatedSourceFile("app/extension/HomePageConstructorsWithAdditionalProtectedMagnetFactory")
+            .hasSourceEquivalentTo(withResource("generated/HomePageConstructorsWithAdditionalProtectedMagnetFactory.java"))
+    }
+
     private fun withResource(name: String): JavaFileObject {
         return JavaFileObjects.forResource(javaClass.simpleName + '/' + name)
     }

--- a/magnet-library/magnet-processor/src/test/resources/MagnetProcessorTest/HomePageConstructorsWithAdditionalPackageProtected.java
+++ b/magnet-library/magnet-processor/src/test/resources/MagnetProcessorTest/HomePageConstructorsWithAdditionalPackageProtected.java
@@ -1,0 +1,21 @@
+package app.extension;
+
+import app.HomeRepository;
+import app.Page;
+import app.UserData;
+import magnet.Instance;
+import magnet.Scope;
+
+@Instance(type = Page.class)
+class HomePageConstructorsWithAdditionalPackageProtected implements Page {
+
+    HomePageConstructorsWithAdditionalPackageProtected(Scope scope) { }
+
+    HomePageConstructorsWithAdditionalPackageProtected() { }
+
+    @Override
+    public void show() {
+        // nop
+    }
+
+}

--- a/magnet-library/magnet-processor/src/test/resources/MagnetProcessorTest/HomePageConstructorsWithAdditionalPrivate.java
+++ b/magnet-library/magnet-processor/src/test/resources/MagnetProcessorTest/HomePageConstructorsWithAdditionalPrivate.java
@@ -1,0 +1,19 @@
+package app.extension;
+
+import app.Page;
+import magnet.Instance;
+import magnet.Scope;
+
+@Instance(type = Page.class)
+class HomePageConstructorsWithAdditionalPrivate implements Page {
+
+    HomePageConstructorsWithAdditionalPrivate(Scope scope) { }
+
+    private HomePageConstructorsWithAdditionalPrivate() { }
+
+    @Override
+    public void show() {
+        // nop
+    }
+
+}

--- a/magnet-library/magnet-processor/src/test/resources/MagnetProcessorTest/HomePageConstructorsWithAdditionalProtected.java
+++ b/magnet-library/magnet-processor/src/test/resources/MagnetProcessorTest/HomePageConstructorsWithAdditionalProtected.java
@@ -1,0 +1,19 @@
+package app.extension;
+
+import app.Page;
+import magnet.Instance;
+import magnet.Scope;
+
+@Instance(type = Page.class)
+class HomePageConstructorsWithAdditionalProtected implements Page {
+
+    HomePageConstructorsWithAdditionalProtected(Scope scope) { }
+
+    protected HomePageConstructorsWithAdditionalProtected() { }
+
+    @Override
+    public void show() {
+        // nop
+    }
+
+}

--- a/magnet-library/magnet-processor/src/test/resources/MagnetProcessorTest/HomePageConstructorsWithNoPublicOrPackageProtected.java
+++ b/magnet-library/magnet-processor/src/test/resources/MagnetProcessorTest/HomePageConstructorsWithNoPublicOrPackageProtected.java
@@ -1,0 +1,21 @@
+package app.extension;
+
+import app.HomeRepository;
+import app.Page;
+import app.UserData;
+import magnet.Instance;
+import magnet.Scope;
+
+@Instance(type = Page.class)
+class HomePageConstructorsWithNoPublicOrPackageProtected implements Page {
+
+    protected HomePageConstructorsWithNoPublicOrPackageProtected(Scope scope) { }
+
+    private HomePageConstructorsWithNoPublicOrPackageProtected() { }
+
+    @Override
+    public void show() {
+        // nop
+    }
+
+}

--- a/magnet-library/magnet-processor/src/test/resources/MagnetProcessorTest/generated/HomePageConstructorsWithAdditionalPrivateMagnetFactory.java
+++ b/magnet-library/magnet-processor/src/test/resources/MagnetProcessorTest/generated/HomePageConstructorsWithAdditionalPrivateMagnetFactory.java
@@ -1,0 +1,17 @@
+package app.extension;
+
+import app.Page;
+import magnet.Scope;
+import magnet.internal.InstanceFactory;
+
+public final class HomePageConstructorsWithAdditionalPrivateMagnetFactory extends InstanceFactory<Page> {
+
+    @Override
+    public Page create(Scope scope) {
+        return new HomePageConstructorsWithAdditionalPrivate(scope);
+    }
+
+    public static Class getType() {
+        return Page.class;
+    }
+}

--- a/magnet-library/magnet-processor/src/test/resources/MagnetProcessorTest/generated/HomePageConstructorsWithAdditionalProtectedMagnetFactory.java
+++ b/magnet-library/magnet-processor/src/test/resources/MagnetProcessorTest/generated/HomePageConstructorsWithAdditionalProtectedMagnetFactory.java
@@ -1,0 +1,17 @@
+package app.extension;
+
+import app.Page;
+import magnet.Scope;
+import magnet.internal.InstanceFactory;
+
+public final class HomePageConstructorsWithAdditionalProtectedMagnetFactory extends InstanceFactory<Page> {
+
+    @Override
+    public Page create(Scope scope) {
+        return new HomePageConstructorsWithAdditionalProtected(scope);
+    }
+
+    public static Class getType() {
+        return Page.class;
+    }
+}


### PR DESCRIPTION
Allow private secondary constructors, for easier handling of legacy code. Fixes #63.

This patch only applies cleanly against `2.8`. I haven't added any tests, because I couldn't pin-point the right spot for it (and there doesn't seem to be a unit test for the changed class). Eventually one should filter out `protected` constructors as well and only take `public` or `package protected` (`internal`) constructors into account.