### PR TITLE
Using proper name for scope parameter when generating a factory

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.3.21'
+    ext.kotlin_version = '1.3.30'
     ext.android_build_version = '3.3.2'
 
     repositories {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 org.gradle.jvmargs=-Xmx1536m
 GROUP=de.halfbit
-VERSION_NAME=3.1-alpha4
+VERSION_NAME=3.1-beta2
 VERSION_CODE=0
 POM_DESCRIPTION=Dependency injection library for Android
 POM_URL=https://github.com/beworker/magnet/

--- a/magnet-processor/src/main/java/magnet/processor/instances/InstanceAnnotationParser.kt
+++ b/magnet-processor/src/main/java/magnet/processor/instances/InstanceAnnotationParser.kt
@@ -99,7 +99,7 @@ internal abstract class AnnotationParser<in E : Element>(
         }
 
         return MethodParameter(
-            name = paramName,
+            name = if (paramExpression is Expression.Scope) PARAM_SCOPE_NAME else paramName,
             expression = paramExpression,
             returnType = paramReturnType,
             parameterType = paramParameterType,

--- a/magnet-processor/src/main/java/magnet/processor/instances/factory/StandardFactoryCreateMethodGenerator.kt
+++ b/magnet-processor/src/main/java/magnet/processor/instances/factory/StandardFactoryCreateMethodGenerator.kt
@@ -8,6 +8,7 @@ import magnet.Scope
 import magnet.processor.instances.CreateMethod
 import magnet.processor.instances.FactoryType
 import magnet.processor.instances.MethodParameter
+import magnet.processor.instances.PARAM_SCOPE_NAME
 import javax.lang.model.element.Modifier
 
 class StandardFactoryCreateMethodGenerator : CreateMethodGenerator {
@@ -31,7 +32,7 @@ class StandardFactoryCreateMethodGenerator : CreateMethodGenerator {
             .methodBuilder("create")
             .addAnnotation(Override::class.java)
             .addModifiers(Modifier.PUBLIC)
-            .addParameter(Scope::class.java, "scope")
+            .addParameter(Scope::class.java, PARAM_SCOPE_NAME)
             .returns(factoryType.interfaceType)
         createMethodCodeBuilder = CodeBlock.builder()
     }

--- a/magnet-processor/src/test/java/magnet/processor/MagnetProcessorTest.kt
+++ b/magnet-processor/src/test/java/magnet/processor/MagnetProcessorTest.kt
@@ -501,6 +501,38 @@ class MagnetProcessorTest {
     }
 
     @Test
+    fun generateFactory_ScopeParameter_CustomName() {
+
+        val path = "ScopeParameter_CustomName"
+        val compilation = Compiler.javac()
+            .withProcessors(MagnetProcessor())
+            .compile(
+                withResource("$path/UnderTest.java")
+            )
+
+        assertThat(compilation).succeededWithoutWarnings()
+        assertThat(compilation)
+            .generatedSourceFile("app/UnderTestMagnetFactory")
+            .hasSourceEquivalentTo(withResource("$path/expected/UnderTestMagnetFactory.java"))
+    }
+
+    @Test
+    fun generateFactory_ScopeParameter_DefaultName() {
+
+        val path = "ScopeParameter_DefaultName"
+        val compilation = Compiler.javac()
+            .withProcessors(MagnetProcessor())
+            .compile(
+                withResource("$path/UnderTest.java")
+            )
+
+        assertThat(compilation).succeededWithoutWarnings()
+        assertThat(compilation)
+            .generatedSourceFile("app/UnderTestMagnetFactory")
+            .hasSourceEquivalentTo(withResource("$path/expected/UnderTestMagnetFactory.java"))
+    }
+
+    @Test
     fun generateFactory_StaticMethodNeedsDependencyWithClassifier() {
         val compilation = Compiler.javac()
             .withProcessors(MagnetProcessor())

--- a/magnet-processor/src/test/resources/MagnetProcessorTest/ScopeParameter_CustomName/UnderTest.java
+++ b/magnet-processor/src/test/resources/MagnetProcessorTest/ScopeParameter_CustomName/UnderTest.java
@@ -1,0 +1,12 @@
+package app;
+
+import magnet.Instance;
+import magnet.Scope;
+
+@Instance(type = UnderTest.class)
+public class UnderTest {
+
+    public UnderTest(Scope parentScope) {
+    }
+
+}

--- a/magnet-processor/src/test/resources/MagnetProcessorTest/ScopeParameter_CustomName/expected/UnderTestMagnetFactory.java
+++ b/magnet-processor/src/test/resources/MagnetProcessorTest/ScopeParameter_CustomName/expected/UnderTestMagnetFactory.java
@@ -1,0 +1,17 @@
+package app;
+
+import magnet.Scope;
+import magnet.internal.Generated;
+import magnet.internal.InstanceFactory;
+
+@Generated
+public final class UnderTestMagnetFactory extends InstanceFactory<UnderTest> {
+    @Override
+    public UnderTest create(Scope scope) {
+        return new UnderTest(scope);
+    }
+
+    public static Class getType() {
+        return UnderTest.class;
+    }
+}

--- a/magnet-processor/src/test/resources/MagnetProcessorTest/ScopeParameter_DefaultName/UnderTest.java
+++ b/magnet-processor/src/test/resources/MagnetProcessorTest/ScopeParameter_DefaultName/UnderTest.java
@@ -1,0 +1,12 @@
+package app;
+
+import magnet.Instance;
+import magnet.Scope;
+
+@Instance(type = UnderTest.class)
+public class UnderTest {
+
+    public UnderTest(Scope scope) {
+    }
+
+}

--- a/magnet-processor/src/test/resources/MagnetProcessorTest/ScopeParameter_DefaultName/expected/UnderTestMagnetFactory.java
+++ b/magnet-processor/src/test/resources/MagnetProcessorTest/ScopeParameter_DefaultName/expected/UnderTestMagnetFactory.java
@@ -1,0 +1,17 @@
+package app;
+
+import magnet.Scope;
+import magnet.internal.Generated;
+import magnet.internal.InstanceFactory;
+
+@Generated
+public final class UnderTestMagnetFactory extends InstanceFactory<UnderTest> {
+    @Override
+    public UnderTest create(Scope scope) {
+        return new UnderTest(scope);
+    }
+
+    public static Class getType() {
+        return UnderTest.class;
+    }
+}


### PR DESCRIPTION
Fixes #84 