### PR TITLE
Remove !(not) from delimiters in selector

### DIFF
--- a/magnet-processor/src/main/java/magnet/processor/instances/aspects/selector/SelectorAttributeParser.kt
+++ b/magnet-processor/src/main/java/magnet/processor/instances/aspects/selector/SelectorAttributeParser.kt
@@ -42,5 +42,5 @@ object SelectorAttributeParser : AttributeParser("selector") {
     }
 }
 
-private val DELIMITER = Regex("[?!\\s|.]+")
+private val DELIMITER = Regex("[\\s|.]+")
 private val OPERATORS = arrayListOf(">", "<", ">=", "<=", "==", "!=", "in", "!in")

--- a/magnet-processor/src/test/java/magnet/processor/SelectorInFactoryClassTest.kt
+++ b/magnet-processor/src/test/java/magnet/processor/SelectorInFactoryClassTest.kt
@@ -122,7 +122,7 @@ class SelectorInFactoryClassTest {
     }
 
     @Test
-    fun `Valid selector (2 operands, !=)`() {
+    fun `Valid selector (1 operand, !=)`() {
         val compilation = Compiler.javac()
             .withProcessors(MagnetProcessor())
             .compile(

--- a/magnet-processor/src/test/java/magnet/processor/SelectorInFactoryClassTest.kt
+++ b/magnet-processor/src/test/java/magnet/processor/SelectorInFactoryClassTest.kt
@@ -106,7 +106,7 @@ class SelectorInFactoryClassTest {
     }
 
     @Test
-    fun `Valid selector (2 operands)`() {
+    fun `Valid selector (2 operands, in)`() {
         val compilation = Compiler.javac()
             .withProcessors(MagnetProcessor())
             .compile(
@@ -119,6 +119,38 @@ class SelectorInFactoryClassTest {
         CompilationSubject.assertThat(compilation)
             .generatedSourceFile("selector/Implementation8MagnetFactory")
             .hasSourceEquivalentTo(withResource("generated/Implementation8MagnetFactory.java"))
+    }
+
+    @Test
+    fun `Valid selector (2 operands, !=)`() {
+        val compilation = Compiler.javac()
+            .withProcessors(MagnetProcessor())
+            .compile(
+                withResource("Interface.java"),
+                withResource("Implementation9.java")
+            )
+
+        CompilationSubject.assertThat(compilation).succeededWithoutWarnings()
+
+        CompilationSubject.assertThat(compilation)
+            .generatedSourceFile("selector/Implementation9MagnetFactory")
+            .hasSourceEquivalentTo(withResource("generated/Implementation9MagnetFactory.java"))
+    }
+
+    @Test
+    fun `Valid selector (2 operands, !in)`() {
+        val compilation = Compiler.javac()
+            .withProcessors(MagnetProcessor())
+            .compile(
+                withResource("Interface.java"),
+                withResource("Implementation10.java")
+            )
+
+        CompilationSubject.assertThat(compilation).succeededWithoutWarnings()
+
+        CompilationSubject.assertThat(compilation)
+            .generatedSourceFile("selector/Implementation10MagnetFactory")
+            .hasSourceEquivalentTo(withResource("generated/Implementation10MagnetFactory.java"))
     }
 
     private fun withResource(name: String): JavaFileObject =

--- a/magnet-processor/src/test/resources/SelectorInFactoryClassTest/Implementation10.java
+++ b/magnet-processor/src/test/resources/SelectorInFactoryClassTest/Implementation10.java
@@ -1,0 +1,9 @@
+package selector;
+
+import magnet.Instance;
+
+@Instance(
+    types = Interface.class,
+    selector = "android.api !in 5..10"
+)
+class Implementation10 implements Interface {}

--- a/magnet-processor/src/test/resources/SelectorInFactoryClassTest/Implementation9.java
+++ b/magnet-processor/src/test/resources/SelectorInFactoryClassTest/Implementation9.java
@@ -1,0 +1,9 @@
+package selector;
+
+import magnet.Instance;
+
+@Instance(
+    types = Interface.class,
+    selector = "android.api != 19"
+)
+class Implementation9 implements Interface {}

--- a/magnet-processor/src/test/resources/SelectorInFactoryClassTest/generated/Implementation10MagnetFactory.java
+++ b/magnet-processor/src/test/resources/SelectorInFactoryClassTest/generated/Implementation10MagnetFactory.java
@@ -1,0 +1,24 @@
+package selector;
+
+import magnet.Scope;
+import magnet.internal.Generated;
+import magnet.internal.InstanceFactory;
+
+@Generated
+public final class Implementation10MagnetFactory extends InstanceFactory<Interface> {
+    private static String[] SELECTOR = { "android", "api", "!in", "5", "10" };
+
+    @Override
+    public Interface create(Scope scope) {
+        return new Implementation10();
+    }
+
+    @Override
+    public String[] getSelector() {
+        return SELECTOR;
+    }
+
+    public static Class getType() {
+        return Interface.class;
+    }
+}

--- a/magnet-processor/src/test/resources/SelectorInFactoryClassTest/generated/Implementation9MagnetFactory.java
+++ b/magnet-processor/src/test/resources/SelectorInFactoryClassTest/generated/Implementation9MagnetFactory.java
@@ -1,0 +1,24 @@
+package selector;
+
+import magnet.Scope;
+import magnet.internal.Generated;
+import magnet.internal.InstanceFactory;
+
+@Generated
+public final class Implementation9MagnetFactory extends InstanceFactory<Interface> {
+    private static String[] SELECTOR = { "android", "api", "!=", "19" };
+
+    @Override
+    public Interface create(Scope scope) {
+        return new Implementation9();
+    }
+
+    @Override
+    public String[] getSelector() {
+        return SELECTOR;
+    }
+
+    public static Class getType() {
+        return Interface.class;
+    }
+}


### PR DESCRIPTION
Fixes #99 

Not sure why it was in the list of delimiters at all.